### PR TITLE
fix bad substitution error when setting syncLimit

### DIFF
--- a/3.4.6/zkStart.sh
+++ b/3.4.6/zkStart.sh
@@ -18,7 +18,7 @@ ZK_INIT_LIMIT=${ZK_INIT_LIMIT:-5}
 echo "initLimit=${ZK_INIT_LIMIT}" | tee -a $ZK_CFG_FILE
 
 ZK_SYNC_LIMIT=${ZK_SYNC_LIMIT:-2}
-echo "syncLimit=${$ZK_SYNC_LIMIT}" | tee -a $ZK_CFG_FILE
+echo "syncLimit=${ZK_SYNC_LIMIT}" | tee -a $ZK_CFG_FILE
 
 echo "dataDir=${ZK_DATA_DIR}" | tee -a $ZK_CFG_FILE
 echo "dataLogDir=${ZK_LOG_DIR}" | tee -a $ZK_CFG_FILE

--- a/3.5.0/zkStart.sh
+++ b/3.5.0/zkStart.sh
@@ -18,7 +18,7 @@ ZK_INIT_LIMIT=${ZK_INIT_LIMIT:-5}
 echo "initLimit=${ZK_INIT_LIMIT}" | tee -a $ZK_CFG_FILE
 
 ZK_SYNC_LIMIT=${ZK_SYNC_LIMIT:-2}
-echo "syncLimit=${$ZK_SYNC_LIMIT}" | tee -a $ZK_CFG_FILE
+echo "syncLimit=${ZK_SYNC_LIMIT}" | tee -a $ZK_CFG_FILE
 
 echo "dataDir=${ZK_DATA_DIR}" | tee -a $ZK_CFG_FILE
 echo "dataLogDir=${ZK_LOG_DIR}" | tee -a $ZK_CFG_FILE

--- a/zkStart.sh
+++ b/zkStart.sh
@@ -18,7 +18,7 @@ ZK_INIT_LIMIT=${ZK_INIT_LIMIT:-5}
 echo "initLimit=${ZK_INIT_LIMIT}" | tee -a $ZK_CFG_FILE
 
 ZK_SYNC_LIMIT=${ZK_SYNC_LIMIT:-2}
-echo "syncLimit=${$ZK_SYNC_LIMIT}" | tee -a $ZK_CFG_FILE
+echo "syncLimit=${ZK_SYNC_LIMIT}" | tee -a $ZK_CFG_FILE
 
 echo "dataDir=${ZK_DATA_DIR}" | tee -a $ZK_CFG_FILE
 echo "dataLogDir=${ZK_LOG_DIR}" | tee -a $ZK_CFG_FILE


### PR DESCRIPTION
encountered an error when starting container "/usr/local/bin/zkStart.sh: line 21: syncLimit=${$ZK_SYNC_LIMIT}: bad substitution", seems to be caused by additional $. Changed the same line in subfolders containing different versions of zookeeper
